### PR TITLE
AP Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+**Update - 20200715**: Tested and functioning on well on the [Raspberry Pi 4].
+
 **Update - 20180601**: Any future development will happen on this new fork. Hoping add stability as well as new SOCs. If you are interesrted in joining the [kinokochat](https://kinokochat.com) team please email human@kinokochat.com.
 
 **Update**: Tested and functioning on well on the [Raspberry Pi 3 B+](https://amzn.to/2jfXhCA) and [Raspberry Pi 3 B](https://amzn.to/2Kq9Doa). Looking to support additional SOCs in upcoming versions. (Disclosure: the Pi links to Amazon are affiliate links, why not?)
 
-**NOTICE**: This project is intended to aid in developing "configure wifi over wifi" solutions for IOT projects using the Raspberry Pi. The main use case for this project is to reproduce functionality common to devices like Nest or Echo, where the user turns on the device, connects to it and configures it for wifi. I have over 800 devices running this software in production and all have had their wifi configured using it. 
+**NOTICE**: This project is intended to aid in developing "configure wifi over wifi" solutions for IOT projects using the Raspberry Pi. The main use case for this project is to reproduce functionality common to devices like Nest or Echo, where the user turns on the device, connects to it and configures it for wifi. I have over 800 devices running this software in production and all have had their wifi configured using it.
 
 **This is not a captive portal project. While I have personaly used it for this, it requires additional networking and can be unstable. I don't support this use and so your millage may vary.**
 
@@ -190,7 +192,7 @@ the Raspberry Pi. We will also need to mount the configuration file.
 
 We will run it in the foreground to observe the startup process. If you want
 it to run the background, you need to remove the `--rm` and pass the `-d` flag. If you want to it restart on reboot or failure, you can pass the flag
-`--restart=unless-stopped`. 
+`--restart=unless-stopped`.
 
 [Read more on the `docker run` command.](https://docs.docker.com/engine/reference/run/)
 
@@ -292,7 +294,7 @@ You should get a JSON response message after a few seconds. If everything went w
 {"status":"OK","message":"Connection","payload":{"ssid":"straylight-g","state":"COMPLETED","ip":"","message":""}}
 ```
 
-You can get the status at any time with the following call to the **status** endpoint. Here is an example:
+You can get the WLAN status at any time with the following call to the **status** endpoint. Here is an example:
 
 ```bash
 # get the wifi status
@@ -303,6 +305,19 @@ Sample return JSON:
 
 ```json
 {"status":"OK","message":"status","payload":{"address":"b7:26:ab:fa:c9:a4","bssid":"50:3b:cb:c8:d3:cd","freq":"2437","group_cipher":"CCMP","id":"0","ip_address":"192.168.86.116","key_mgmt":"WPA2-PSK","mode":"station","p2p_device_address":"fa:27:eb:fe:c9:ab","pairwise_cipher":"CCMP","ssid":"straylight-g","uuid":"a736659a-ae85-5e03-9754-dd808ea0d7f2","wpa_state":"COMPLETED"}}
+```
+
+You can get the AP status at any time with the following call to the **ap** endpoint. Here is an example:
+
+```bash
+# get the ap status
+$ curl -w "\n" http://localhost:8080/ap
+```
+
+Sample return JSON:
+
+```json
+{"status":"OK","message":"status","payload":{"beacon_int":"100","bss":"uap0","bssid":"dc:a6:32:62:4b:0e","cac_time_left_seconds":"N/A","cac_time_seconds":"0","channel":"6","clients":[],"dtim_period":"2","freq":"2437","ht_op_mode":"0x0","ieee80211ac":"0","ieee80211ax":"0","ieee80211n":"0","max_txpower":"30","num_sta":"0","num_sta_ht40_intolerant":"0","num_sta_ht_20_mhz":"0","num_sta_ht_no_gf":"0","num_sta_no_ht":"0","num_sta_no_short_preamble":"0","num_sta_no_short_slot_time":"0","num_sta_non_erp":"0","olbc":"0","olbc_ht":"0","phy":"phy0","secondary_channel":"0","ssid":"your-ssid","state":"ENABLED","supported_rates":"02 04 0b 16 0c 12 18 24 30 48 60 6c"}}
 ```
 
 ### Check the network interface status

--- a/iotwifi/commands.go
+++ b/iotwifi/commands.go
@@ -47,6 +47,20 @@ func (c *Command) CheckApInterface() {
 	go c.Runner.ProcessCmd("ifconfig_uap0", cmd)
 }
 
+// EnableAp enables the AP interface.
+func (c *Command) EnableAp() {
+	cmd := exec.Command("hostapd_cli", "-i", "uap0", "enable")
+	cmd.Start()
+	cmd.Wait()
+}
+
+// DisableAp disables the AP interface.
+func (c *Command) DisableAp() {
+	cmd := exec.Command("hostapd_cli", "-i", "uap0", "disable")
+	cmd.Start()
+	cmd.Wait()
+}
+
 // StartWpaSupplicant starts wpa_supplicant.
 func (c *Command) StartWpaSupplicant() {
 

--- a/iotwifi/iotwifi.go
+++ b/iotwifi/iotwifi.go
@@ -123,7 +123,7 @@ func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 	go func() {
 		for {
 			time.Sleep(30 * time.Second)
-			if status, ok := wpacfg.Status(); ok == nil && status["wpa_state"] == "COMPLETED" {
+			if status, err := wpacfg.Status(); err == nil && status["wpa_state"] == "COMPLETED" {
 				log.Info("Connection detected - stopping AP...")
 				time.Sleep(5 * time.Second)
 				command.DisableAp()

--- a/iotwifi/iotwifi.go
+++ b/iotwifi/iotwifi.go
@@ -113,8 +113,10 @@ func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 	// Start supplicant and attempt to connect
 	command.StartWpaSupplicant()
 
-	// Start DNSmasq
+	// Do a single scan
 	time.Sleep(5 * time.Second)
+	wpacfg.ScanNetworks()
+
 	command.StartDnsmasq()
 
 	// monitor for a future connection - shut down AP when it occurs

--- a/iotwifi/iotwifi.go
+++ b/iotwifi/iotwifi.go
@@ -106,51 +106,30 @@ func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 	})
 
 	wpacfg := NewWpaCfg(log, cfgLocation)
-	command.Runner.Commands["hostapd"] = wpacfg.StartAP()
+	wpacfg.StartAP()
 
 	time.Sleep(10 * time.Second)
 
 	// Start supplicant and attempt to connect
 	command.StartWpaSupplicant()
 
-	// Initial scan
+	// Start DNSmasq
 	time.Sleep(5 * time.Second)
-	wpacfg.ScanNetworks()
-
 	command.StartDnsmasq()
 
-	/* Check if we connected, start soft-ap if not
-	time.Sleep(30 * time.Second)
-	if status, ok := wpacfg.Status(); ok == nil && status["wpa_state"] != "COMPLETED" {
-		log.Info("No connection detected - starting AP...")
-		time.Sleep(10 * time.Second)
-		command.StartDnsmasq()
-	}*/
-
-
-	// TODO: check to see if we are stuck in a scanning state before
-	// if in a scanning state set a timeout before resetting
-	go func() {
-		for {
-			wpacfg.ScanNetworks()
-			time.Sleep(30 * time.Second)
-		}
-	}()
-
-	// disable soft-ap once network connection occurs
+	// monitor for a future connection - shut down AP when it occurs
 	go func() {
 		for {
 			time.Sleep(30 * time.Second)
 			if status, ok := wpacfg.Status(); ok == nil && status["wpa_state"] == "COMPLETED" {
 				log.Info("Connection detected - stopping AP...")
-				time.Sleep(10 * time.Second)
-				command.Runner.KillCmd("dnsmasq")
-				command.Runner.KillCmd("hostapd")
-				command.RemoveApInterface()
+				time.Sleep(5 * time.Second)
+				command.DisableAp()
 				break
 			}
 		}
 	}()
+
 
 	// staticFields for logger
 	staticFields := make(map[string]interface{})
@@ -225,16 +204,5 @@ func (c *CmdRunner) ProcessCmd(id string, cmd *exec.Cmd) {
 
 	if err != nil {
 		panic(err)
-	}
-}
-
-// KillCmd kills an internal command.
-func (c *CmdRunner) KillCmd(id string) {
-	c.Log.Debug("KillCmd got %s", id)
-
-	if cmd, ok := c.Commands[id]; ok {
-		if err := cmd.Process.Kill(); err != nil {
-			panic(err)
-		}
 	}
 }

--- a/iotwifi/wpacfg.go
+++ b/iotwifi/wpacfg.go
@@ -129,14 +129,18 @@ rsn_pairwise=CCMP`
 func (wpa *WpaCfg) APStatus() (map[string]interface{}, error) {
 	cfgMap := make(map[string]interface{}, 0)
 
-	stateOut, err := exec.Command("hostapd_cli", "-i", "uap0", "get_config").Output()
+	// get the standard stats
+	stateOut, err := exec.Command("hostapd_cli", "-i", "uap0", "status").Output()
 	if err != nil {
 		wpa.Log.Fatal("Got error checking state: %s", err.Error())
 		return cfgMap, err
 	}
 
+	// Remove the indexing associated with ssid, bssid, and bss
+	stateOut = bytes.ReplaceAll(stateOut, []byte("[0]"), []byte(""))
 	cfgMap = cfgMapper(stateOut)
 
+	// get the list of connected clients
 	clientsOut, err := exec.Command("hostapd_cli", "-i", "uap0", "list_sta").Output()
 	if err != nil {
 		wpa.Log.Fatal("Got error checking clients: %s", err.Error())

--- a/iotwifi/wpacfg.go
+++ b/iotwifi/wpacfg.go
@@ -129,7 +129,7 @@ rsn_pairwise=CCMP`
 func (wpa *WpaCfg) APStatus() (map[string]interface{}, error) {
 	cfgMap := make(map[string]interface{}, 0)
 
-	stateOut, err := exec.Command("hostapd_cli", "-i", "uap0", "status").Output()
+	stateOut, err := exec.Command("hostapd_cli", "-i", "uap0", "get_config").Output()
 	if err != nil {
 		wpa.Log.Fatal("Got error checking state: %s", err.Error())
 		return cfgMap, err
@@ -146,7 +146,9 @@ func (wpa *WpaCfg) APStatus() (map[string]interface{}, error) {
 	clients := []string{};
 	lines := bytes.Split(clientsOut, []byte("\n"))
 	for _, line := range lines {
-		clients = append(clients, string(line))
+		if len(line) > 1 {
+			clients = append(clients, string(line))
+		}
 	}
 	cfgMap["clients"] = clients
 

--- a/main.go
+++ b/main.go
@@ -90,7 +90,19 @@ func main() {
 		w.Write(ret)
 	}
 
-	// handle /status POSTs json in the form of iotwifi.WpaConnect
+	// handle /apstatus GETs
+	apStatusHandler := func(w http.ResponseWriter, r *http.Request) {
+
+		status, err := wpacfg.APStatus()
+		if err != nil {
+			blog.Error(err.Error())
+			return
+		}
+
+		apiPayloadReturn(w, "status", status)
+	}
+
+	// handle /status GETs
 	statusHandler := func(w http.ResponseWriter, r *http.Request) {
 
 		status, err := wpacfg.Status()
@@ -192,6 +204,7 @@ func main() {
 	r.Use(logHandler)
 
 	// set app routes
+	r.HandleFunc("/ap", apStatusHandler)
 	r.HandleFunc("/status", statusHandler)
 	r.HandleFunc("/connect", connectHandler).Methods("POST")
 	r.HandleFunc("/scan", scanHandler)


### PR DESCRIPTION
This PR exposes AP status over a `/ap` endpoint.  It works very similar to the normal `status` endpoint.

```
curl http://localhost:8080/ap
```
Formatted Response
```
{
  "status": "OK",
  "message": "status",
  "payload": {
    "beacon_int": "100",
    "bss": "uap0",
    "bssid": "dc:a6:32:62:4b:0e",
    "cac_time_left_seconds": "N/A",
    "cac_time_seconds": "0",
    "channel": "6",
    "clients": [],
    "dtim_period": "2",
    "freq": "2437",
    "ht_op_mode": "0x0",
    "ieee80211ac": "0",
    "ieee80211ax": "0",
    "ieee80211n": "0",
    "num_sta": "0",
    "num_sta_ht40_intolerant": "0",
    "num_sta_ht_20_mhz": "0",
    "num_sta_ht_no_gf": "0",
    "num_sta_no_ht": "0",
    "num_sta_no_short_preamble": "0",
    "num_sta_no_short_slot_time": "0",
    "num_sta_non_erp": "0",
    "olbc": "0",
    "olbc_ht": "0",
    "phy": "phy0",
    "secondary_channel": "0",
    "ssid": "kinoko-chat",
    "state": "DISABLED"
  }
}
```

AP status works by enabling support for `hostapd_cli` and using its `status` and `list_sta` commands. 

The important fields in the result `payload` are
`state`: ENABLED or DISABLED (we now disable the AP once wifi connects)
`clients`: a list of MAC addresses for connected clients
