### PR TITLE
Hostapd logs

### DIFF
--- a/iotwifi/commands.go
+++ b/iotwifi/commands.go
@@ -2,6 +2,7 @@ package iotwifi
 
 import (
 	"os/exec"
+	"time"
 
 	"github.com/bhoriuchi/go-bunyan/bunyan"
 )
@@ -92,4 +93,39 @@ func (c *Command) StartDnsmasq() {
 
 	cmd := exec.Command("dnsmasq", args...)
 	go c.Runner.ProcessCmd("dnsmasq", cmd)
+}
+
+// StartHostapd starts hostapd.
+func (c *Command) StartHostapd(ssid string, psk string, channel string) {
+	args := []string{
+		"-d", // enable debug
+		"/dev/stdin",
+	}
+	cmd := exec.Command("hostapd", args...)
+
+	cfg := `interface=uap0
+ssid=` + ssid + `
+hw_mode=g
+channel=` + channel + `
+ctrl_interface=/var/run/hostapd
+ctrl_interface_group=0
+macaddr_acl=0
+auth_algs=1
+ignore_broadcast_ssid=0
+wpa=2
+wpa_passphrase=` + psk + `
+wpa_key_mgmt=WPA-PSK
+wpa_pairwise=TKIP
+rsn_pairwise=CCMP`
+
+	c.Log.Info("Hostapd CFG: %s", cfg)
+
+	// handle in pipe here to pass cfg, out/error handled by Runner
+	hostapdPipe, _ := cmd.StdinPipe()
+	hostapdPipe.Write([]byte(cfg))
+
+	go c.Runner.ProcessCmd("hostapd", cmd)
+
+	time.Sleep(2)
+	hostapdPipe.Close()
 }

--- a/iotwifi/commands.go
+++ b/iotwifi/commands.go
@@ -66,7 +66,6 @@ func (c *Command) DisableAp() {
 func (c *Command) StartWpaSupplicant() {
 
 	args := []string{
-		"-d",
 		"-Dnl80211",
 		"-iwlan0",
 		"-c" + c.SetupCfg.WpaSupplicantCfg.CfgFile,
@@ -98,7 +97,6 @@ func (c *Command) StartDnsmasq() {
 // StartHostapd starts hostapd.
 func (c *Command) StartHostapd(ssid string, psk string, channel string) {
 	args := []string{
-		"-d", // enable debug
 		"/dev/stdin",
 	}
 	cmd := exec.Command("hostapd", args...)

--- a/iotwifi/commands.go
+++ b/iotwifi/commands.go
@@ -120,10 +120,9 @@ rsn_pairwise=CCMP`
 
 	// handle in pipe here to pass cfg, out/error handled by Runner
 	hostapdPipe, _ := cmd.StdinPipe()
+	defer hostapdPipe.Close()
 	hostapdPipe.Write([]byte(cfg))
 
 	go c.Runner.ProcessCmd("hostapd", cmd)
-
-	time.Sleep(2)
-	hostapdPipe.Close()
+	time.Sleep(2)	// brief delay before closing pipe
 }

--- a/iotwifi/iotwifi.go
+++ b/iotwifi/iotwifi.go
@@ -112,7 +112,7 @@ func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 	command.AddApInterface()
 	command.UpApInterface()
 	command.ConfigureApInterface()
-	command.StartHostapd(wpacfg.WpaCfg.HostApdCfg.Ssid, wpacfg.WpaCfg.HostApdCfg.Channel, wpacfg.WpaCfg.HostApdCfg.WpaPassphrase)
+	command.StartHostapd(wpacfg.WpaCfg.HostApdCfg.Ssid, wpacfg.WpaCfg.HostApdCfg.WpaPassphrase, wpacfg.WpaCfg.HostApdCfg.Channel)
 
 	time.Sleep(10 * time.Second)
 

--- a/iotwifi/iotwifi.go
+++ b/iotwifi/iotwifi.go
@@ -106,7 +106,13 @@ func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 	})
 
 	wpacfg := NewWpaCfg(log, cfgLocation)
-	wpacfg.StartAP()
+
+	// bring up soft AP
+	command.RemoveApInterface()
+	command.AddApInterface()
+	command.UpApInterface()
+	command.ConfigureApInterface()
+	command.StartHostapd(wpacfg.WpaCfg.HostApdCfg.Ssid, wpacfg.WpaCfg.HostApdCfg.Channel, wpacfg.WpaCfg.HostApdCfg.WpaPassphrase)
 
 	time.Sleep(10 * time.Second)
 
@@ -131,7 +137,6 @@ func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 			}
 		}
 	}()
-
 
 	// staticFields for logger
 	staticFields := make(map[string]interface{})

--- a/iotwifi/wpacfg.go
+++ b/iotwifi/wpacfg.go
@@ -1,7 +1,6 @@
 package iotwifi
 
 import (
-	"bufio"
 	"bytes"
 	"os/exec"
 	"regexp"
@@ -56,75 +55,6 @@ func NewWpaCfg(log bunyan.Logger, cfgLocation string) *WpaCfg {
 	}
 }
 
-// StartAP starts AP mode.
-func (wpa *WpaCfg) StartAP() {
-	wpa.Log.Info("Starting Hostapd.")
-
-	command := &Command{
-		Log:      wpa.Log,
-		SetupCfg: wpa.WpaCfg,
-	}
-
-	command.RemoveApInterface()
-	command.AddApInterface()
-	command.UpApInterface()
-	command.ConfigureApInterface()
-
-	cmd := exec.Command("hostapd", "-d", "/dev/stdin")
-
-	// pipes
-	hostapdPipe, _ := cmd.StdinPipe()
-	cmdStdoutReader, err := cmd.StdoutPipe()
-	if err != nil {
-		panic(err)
-	}
-
-	messages := make(chan string, 1)
-
-	stdOutScanner := bufio.NewScanner(cmdStdoutReader)
-	go func() {
-		for stdOutScanner.Scan() {
-			wpa.Log.Info("HOSTAPD GOT: %s", stdOutScanner.Text())
-			messages <- stdOutScanner.Text()
-		}
-	}()
-
-	cfg := `interface=uap0
-ssid=` + wpa.WpaCfg.HostApdCfg.Ssid + `
-hw_mode=g
-channel=` + wpa.WpaCfg.HostApdCfg.Channel + `
-ctrl_interface=/var/run/hostapd
-ctrl_interface_group=0
-macaddr_acl=0
-auth_algs=1
-ignore_broadcast_ssid=0
-wpa=2
-wpa_passphrase=` + wpa.WpaCfg.HostApdCfg.WpaPassphrase + `
-wpa_key_mgmt=WPA-PSK
-wpa_pairwise=TKIP
-rsn_pairwise=CCMP`
-
-	wpa.Log.Info("Hostapd CFG: %s", cfg)
-	hostapdPipe.Write([]byte(cfg))
-
-	cmd.Start()
-	hostapdPipe.Close()
-
-	for {
-		out := <-messages // Block until we receive a message on the channel
-		if strings.Contains(out, "uap0: AP-DISABLED") {
-			wpa.Log.Info("Hostapd DISABLED")
-			//cmd.Process.Kill()
-			//cmd.Wait()
-			return
-		}
-		if strings.Contains(out, "uap0: AP-ENABLED") {
-			wpa.Log.Info("Hostapd ENABLED")
-			return
-		}
-	}
-}
-
 // Status returns the AP status.
 func (wpa *WpaCfg) APStatus() (map[string]interface{}, error) {
 	cfgMap := make(map[string]interface{}, 0)
@@ -140,7 +70,9 @@ func (wpa *WpaCfg) APStatus() (map[string]interface{}, error) {
 	stateOut = bytes.ReplaceAll(stateOut, []byte("[0]"), []byte(""))
 
 	// Parse and convert to interface map
-	for key, val := range cfgMapper(stateOut){cfgMap[key] = val}
+	for key, val := range cfgMapper(stateOut) {
+		cfgMap[key] = val
+	}
 
 	// get the list of connected clients
 	clientsOut, err := exec.Command("hostapd_cli", "-i", "uap0", "list_sta").Output()
@@ -149,7 +81,7 @@ func (wpa *WpaCfg) APStatus() (map[string]interface{}, error) {
 		return cfgMap, err
 	}
 
-	clients := []string{};
+	clients := []string{}
 	lines := strings.Split(string(clientsOut), "\n")
 	for _, line := range lines {
 		if len(line) > 1 {


### PR DESCRIPTION
I noticed during debugging that the log output of the hostapd process halts shortly after startup. I suspected this was related to the log pipe not being persisted after the `StartAP()` method exited.

To address this I pulled hostapd out of the `wpacfg.go` and execute it using the command runner similar to how `dnsmasq` is handled.  This has two notable improvements
1. Logs now continue to be output indefinitely
2. It makes more sense...why would you configure the AP in the wpa related logic?

An unexpected benefit of this is our hostapd service is no longer showing stability or lockup issues.  Prior to this PR - the `hostapd_cli` would regularly fail to connect to hostapd after a random appearing amount of runtime (usually several minutes).  I suspect that mishandled log pipe may have been the cause of this!

Finally, I disabled the `-d` arg to both hostapd and wpa_supplicant.  This was creating incredibly verbose logs which are not required in a production environment.