### PR TITLE
Check eth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/wifi-server /go/src/github.com/
 FROM arm32v7/alpine:3.11
 
 RUN apk update
-RUN apk add bridge hostapd wireless-tools wpa_supplicant dnsmasq iw
+RUN apk add bridge hostapd wireless-tools wpa_supplicant dnsmasq iw ethtool
 
 RUN mkdir -p /etc/wpa_supplicant/
 COPY ./dev/configs/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf

--- a/iotwifi/commands.go
+++ b/iotwifi/commands.go
@@ -81,6 +81,7 @@ func (c *Command) StartDnsmasq() {
 	args := []string{
 		"--no-hosts", // Don't read the hostnames in /etc/hosts.
 		"--keep-in-foreground",
+		"--interface=uap0",
 		"--log-queries",
 		"--no-resolv",
 		"--address=" + c.SetupCfg.DnsmasqCfg.Address,

--- a/iotwifi/iotwifi.go
+++ b/iotwifi/iotwifi.go
@@ -152,7 +152,7 @@ func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 				break
 			}
 
-			time.Sleep(120 * time.Second)
+			time.Sleep(30 * time.Second)
 		}
 	}()
 

--- a/iotwifi/iotwifi.go
+++ b/iotwifi/iotwifi.go
@@ -152,7 +152,7 @@ func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 				break
 			}
 
-			time.Sleep(60 * time.Second)
+			time.Sleep(120 * time.Second)
 		}
 	}()
 

--- a/iotwifi/iotwifi.go
+++ b/iotwifi/iotwifi.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/bhoriuchi/go-bunyan/bunyan"
@@ -75,6 +76,15 @@ func loadCfg(cfgLocation string) (*SetupCfg, error) {
 	return v, err
 }
 
+// EthActive checks if the ethernet interface is active
+func EthActive() bool {
+	ethOut, err := exec.Command("ethtool", "eth0").Output()
+	if err != nil {
+		panic(err)
+	}
+	return strings.Contains(string(ethOut), "Link detected: yes")
+}
+
 // RunWifi starts AP and Station modes.
 func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 
@@ -128,13 +138,21 @@ func RunWifi(log bunyan.Logger, messages chan CmdMessage, cfgLocation string) {
 	// monitor for a future connection - shut down AP when it occurs
 	go func() {
 		for {
-			time.Sleep(30 * time.Second)
-			if status, err := wpacfg.Status(); err == nil && status["wpa_state"] == "COMPLETED" {
-				log.Info("Connection detected - stopping AP...")
+			if EthActive() {
+				log.Info("Eth Connection detected - stopping AP...")
 				time.Sleep(5 * time.Second)
 				command.DisableAp()
 				break
 			}
+
+			if status, ok := wpacfg.Status(); ok == nil && status["wpa_state"] == "COMPLETED" {
+				log.Info("WiFi Connection detected - stopping AP...")
+				time.Sleep(5 * time.Second)
+				command.DisableAp()
+				break
+			}
+
+			time.Sleep(60 * time.Second)
 		}
 	}()
 


### PR DESCRIPTION
This PR shuts down the AP when ethernet is connected.

I also limited our dnsmasq to the `uap0` interface after noticing it attempting to process dhcp requests coming in on eth0 when ethernet is connected.